### PR TITLE
Adding ability to ignore some/all collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ plex:
 dizquetv:
   url: "INSERT_DIZQUETV_URL_HERE:8000"
   debug: True
+  ignore: False
   discord:
     url: "INSERT_DISCORD_WEBHOOK_URL_HERE"
     username: "pmm-dizquetv"
@@ -50,6 +51,7 @@ defaults:
     fillers:
       - Commercials
     channel_group: TV
+    ignore: True
 libraries:
   Movies:
     Pixar:
@@ -75,13 +77,17 @@ The `plex` section of the configuration points to the location and the authoriza
 The `dizquetv` section points to your DizqueTV instances and provides a location for more general configuration values,
 such as
 
-| value   | setting                                                             |
-|---------|---------------------------------------------------------------------|
-| debug   | enable pmm-dizquetv logging debug verbosity, default is `false`     |
-| discord | pmm-dizquetv can send notifications to discord, if settings applied |
-|         | `url`: Discord webhook url                                          |
-|         | `username`: Username for discord, `pmm-dizquetv` is default         |
-|         | `avatar`: url of the avatar to display in Discord                   |
+| value    | setting                                                             |
+|----------|---------------------------------------------------------------------|
+| debug    | enable pmm-dizquetv logging debug verbosity, default is `false`     |
+| discord  | pmm-dizquetv can send notifications to discord, if settings applied |
+|          | `url`: Discord webhook url                                          |
+|          | `username`: Username for discord, `pmm-dizquetv` is default         |
+|          | `avatar`: url of the avatar to display in Discord                   |
+| ignore   | If set to `False`, all collections will be synced to DizqueTV       |
+|          | If set to `True`, only collection where `ignore` is overridden      |
+|          | will be synced                                                      |
+|          | Default value is `False`                                             |
 
 #### defaults
 The `defaults` section allows for overriding the default values for each `library`
@@ -94,6 +100,7 @@ The `defaults` section allows for overriding the default values for each `librar
 |           | `fillers`: a list of filler Lists already defined within DizqueTV                         |
 |           | `channel_group`: Default value for the Channel within DizqueTV                            |
 |           | `ignore`: Ignore any changes made to any collection in this library                       |
+|           | `ignore`: Overrides the `ignore` setting for all collections in this specific library     |
 
 
 #### libraries
@@ -112,7 +119,7 @@ the following can be defined:
 |                | `fillers`: a list of filler Lists already defined within DizqueTV                                         |
 |                | `channel_name`: Allows a manually specified channel name. Default is `<plex_library> - <plex_collection>` |
 |                | `channel_group`: Value for the Channel within DizqueTV                                                    |
-|                | `ignore`: Ignore any changes made to this collection                                                      |
+|                | `ignore`: Ignore any changes made to this collection, overrides the library and system settings           |
 
 
 ### docker-compose

--- a/api/main.py
+++ b/api/main.py
@@ -156,7 +156,7 @@ def process_collection(collection: Collection):
 
     # check if the collection or library is marked to be ignored
     if channel_config['ignore']:
-        logger.info("Ignoring collection: %s", channel_name)
+        logger.info("Ignoring collection: %s, because the 'ignore' flag was set", channel_name)
         return
 
     # get the channel number, will return 0 if no channel exists

--- a/api/main.py
+++ b/api/main.py
@@ -25,6 +25,10 @@ import pmmdtv_logger
 # create the API
 APP = FastAPI()
 
+# globals for reporting purposes
+# igmored collections
+ignored_collections = []
+
 # allow calls from anywhere
 APP.add_middleware(
     CORSMiddleware,
@@ -105,6 +109,8 @@ def hook_start(start_time: StartRun):
     """ Webhook for when a PMM run starts """
     logger = pmmdtv_logger.get_logger()
     logger.info("PMM Run started at: %s", start_time.start_time)
+    # reset the list of ignored collections
+    ignored_collections = []
     # Validate the configuration
     _ = pmmdtv_config.get_config(validate=True)
     return Response(status_code=200)
@@ -115,6 +121,16 @@ def hook_end(end_time: EndRun):
     """ Webhook for when a PMM run ends """
     logger = pmmdtv_logger.get_logger()
     logger.info("PMM Run ended at: %s", end_time.end_time)
+    message = "Plex-Meta-Manager run complete, "
+    message += "collections/channels will continue in the background."
+
+    if ignored_collections:
+        message += "\nThe following collections were updated but "
+        message += "ignored due to pmm-dizquetv configuration:\n"
+        for this_coll in ignored_collections:
+            message += "- " + this_coll + "\n"
+
+    logger.info(message)
     return Response(status_code=200)
 
 
@@ -123,9 +139,21 @@ def hook_update(collection: Collection, background_tasks: BackgroundTasks):
     """The actual webhook, /collection, which gets all collection updates"""
     logger = pmmdtv_logger.get_logger()
     logger.debug("Collection Requested: %s", pformat(collection))
-    # Process the collection in the background
-    background_tasks.add_task(process_collection, collection)
-    # send back an ACCEPTED response
+
+    # get the collection config and see if we should ignore this one
+    channel_config = pmmdtv_config.get_collection_config(col_section=collection.library_name,
+                                                         col_name=collection.collection)
+    full_name = collection.library_name + " - " + collection.collection
+
+    # check if the collection or library is marked to be ignored
+    if channel_config['ignore']:
+        ignored_collections.append(full_name)
+        logger.info("Ignoring collection: %s, because the 'ignore' flag was set", full_name)
+    else:
+        # Process the collection in the background
+        background_tasks.add_task(process_collection, collection)
+
+    # send back an ACCEPTED response, regardless of if it is ignored
     return Response(status_code=202)
 
 def process_collection(collection: Collection):
@@ -153,11 +181,6 @@ def process_collection(collection: Collection):
 
     channel_name = channel_config['channel_name']
     logger.info("Channel name: %s", channel_name)
-
-    # check if the collection or library is marked to be ignored
-    if channel_config['ignore']:
-        logger.info("Ignoring collection: %s, because the 'ignore' flag was set", channel_name)
-        return
 
     # get the channel number, will return 0 if no channel exists
     channel = dtv_get_channel_number(config=config, name=channel_name)


### PR DESCRIPTION
Per request from a user, adding the ability to ignore (not sync) collections based on:
- Individual config for that collection
- All collections in a library
- All collections within Plex

This is done by adding a setting `ignore` to the configuration file at the approproate location

Collection settings override library settings which override the system setting

For more information consult the project README